### PR TITLE
take equals instead of ==

### DIFF
--- a/skiplist/skiplist.go
+++ b/skiplist/skiplist.go
@@ -366,7 +366,7 @@ func (s SkipList) randomLevel() (n int) {
 func (s *SkipList) Get(key interface{}) (value interface{}, ok bool) {
 	candidate := s.getPath(s.header, nil, key)
 
-	if candidate == nil || candidate.key != key {
+	if candidate == nil || !s.equals(candidate.key, key) {
 		return nil, false
 	}
 
@@ -413,7 +413,7 @@ func (s *SkipList) Set(key, value interface{}) {
 	update := make([]*node, s.level()+1, s.effectiveMaxLevel()+1)
 	candidate := s.getPath(s.header, update, key)
 
-	if candidate != nil && candidate.key == key {
+	if candidate != nil && s.equals(candidate.key, key) {
 		candidate.value = value
 		return
 	}
@@ -468,7 +468,7 @@ func (s *SkipList) Delete(key interface{}) (value interface{}, ok bool) {
 	update := make([]*node, s.level()+1, s.effectiveMaxLevel())
 	candidate := s.getPath(s.header, update, key)
 
-	if candidate == nil || candidate.key != key {
+	if candidate == nil || !s.equals(candidate.key, key) {
 		return nil, false
 	}
 
@@ -492,6 +492,10 @@ func (s *SkipList) Delete(key interface{}) (value interface{}, ok bool) {
 	s.length--
 
 	return candidate.value, true
+}
+
+func (s *SkipList) equals(l, r interface{}) bool {
+	return (!s.lessThan(l, r)) && !s.lessThan(r, l)
 }
 
 // NewCustomMap returns a new SkipList that will use lessThan as the


### PR DESCRIPTION
hi Ric,

I tries take advantage of goskiplist as a sorted set in my part time project, but got this error:

```
panic: runtime error: comparing uncomparable type FileMeta

goroutine 36 [running]:
testing.tRunner.func1(0xc00018e100)
	/usr/local/Cellar/go/1.12/libexec/src/testing/testing.go:830 +0x388
panic(0x12e38a0, 0xc0000a0da0)
	/usr/local/Cellar/go/1.12/libexec/src/runtime/panic.go:522 +0x1b5
github.com/Fleurer/miaomiao/util/goskiplist/skiplist.(*SkipList).Set(0xc0000a2c90, 0x1310a00, 0xc0000b2f40, 0x0, 0x0)
	/Users/fleuria/night/miaomiao/util/goskiplist/skiplist/skiplist.go:416 +0x62a
github.com/fleurer/miaomiao/util/goskiplist/skiplist.(*Set).Add(...)
	/Users/fleuria/night/miaomiao/util/goskiplist/skiplist/skiplist.go:596
github.com/Fleurer/miaomiao/tool.(*Builder).Apply(0xc00019a000, 0xc00004bed8)
	/Users/fleuria/night/miaomiao/tool/builder.go:67 +0x31d
...
```

FileMeta is a struct so it can not be compared using ==/!=. I've noticed there's a comment about this: `Additionally, Ordered instances should behave properly when compared using == and !=.` But maybe it's possible to use the `lessThan` function to get the equality between the values?

Regards.